### PR TITLE
Fix unbound local error.

### DIFF
--- a/patches/external_pr/ui.py
+++ b/patches/external_pr/ui.py
@@ -39,7 +39,8 @@ Hypernetwork saved to {html.escape(filename)}
             shared.loaded_hypernetwork = initial_hypernetwork
         else:
             shared.loaded_hypernetworks = []
-        del hypernetwork
+        if 'hypernetwork' in locals():
+            del hypernetwork
         gc.collect()
         shared.sd_model.cond_stage_model.to(devices.device)
         shared.sd_model.first_stage_model.to(devices.device)


### PR DESCRIPTION
Fixes `UnboundLocalError: local variable 'hypernetwork' referenced before assignment` error in finally block if the code in the try-catch raises an exception before `hypernetwork` has been set.